### PR TITLE
Filtering prompts list by tags

### DIFF
--- a/api/v1/prompts.py
+++ b/api/v1/prompts.py
@@ -4,19 +4,14 @@ from sqlalchemy.orm import joinedload
 from ...models.pd.base import PromptTagBaseModel
 from ...utils.constants import PROMPT_LIB_MODE
 from ...utils.create_utils import create_version
+from ...utils.prompt_utils import list_prompts
 from ...utils.prompt_utils_legacy import prompts_create_prompt
 from flask import request, g
 from pylon.core.tools import web, log
 from tools import api_tools, config as c, db, auth
 
 from pydantic import ValidationError
-from ...models.all import (
-    Prompt,
-    PromptVersion,
-    PromptVariable,
-    PromptMessage,
-    PromptTag,
-)
+from ...models.all import Prompt
 from ...models.pd.create import PromptCreateModel
 from ...models.pd.detail import PromptDetailModel, PromptVersionDetailModel
 from ...models.pd.list import PromptListModel, PromptTagListModel
@@ -66,7 +61,7 @@ class PromptLibAPI(api_tools.APIModeHandler):
     def get(self, project_id: int | None = None, **kwargs):
         project_id = self._get_project_id(project_id)
         # list prompts
-        total, prompts = self.module.list_prompts(project_id, request.args)
+        total, prompts = list_prompts(project_id, request.args)
         # parsing
         all_authors = set()
         parsed: List[PromptListModel] = []

--- a/api/v1/prompts.py
+++ b/api/v1/prompts.py
@@ -10,7 +10,13 @@ from pylon.core.tools import web, log
 from tools import api_tools, config as c, db, auth
 
 from pydantic import ValidationError
-from ...models.all import Prompt, PromptVersion, PromptVariable, PromptMessage, PromptTag
+from ...models.all import (
+    Prompt,
+    PromptVersion,
+    PromptVariable,
+    PromptMessage,
+    PromptTag,
+)
 from ...models.pd.create import PromptCreateModel
 from ...models.pd.detail import PromptDetailModel, PromptVersionDetailModel
 from ...models.pd.list import PromptListModel, PromptTagListModel
@@ -18,25 +24,31 @@ import json
 
 
 class ProjectAPI(api_tools.APIModeHandler):
-    @auth.decorators.check_api({
-        "permissions": ["models.prompts.prompts.list"],
-        "recommended_roles": {
-            c.ADMINISTRATION_MODE: {"admin": True, "editor": True, "viewer": False},
-            c.DEFAULT_MODE: {"admin": True, "editor": True, "viewer": False},
-        }})
+    @auth.decorators.check_api(
+        {
+            "permissions": ["models.prompts.prompts.list"],
+            "recommended_roles": {
+                c.ADMINISTRATION_MODE: {"admin": True, "editor": True, "viewer": False},
+                c.DEFAULT_MODE: {"admin": True, "editor": True, "viewer": False},
+            },
+        }
+    )
     def get(self, project_id):
-        log.info('Getting all prompts for project %s', project_id)
-        with_versions = request.args.get('versions', '').lower() == 'true'
+        log.info("Getting all prompts for project %s", project_id)
+        with_versions = request.args.get("versions", "").lower() == "true"
         prompts = self.module.get_all(project_id, with_versions)
 
         return prompts
 
-    @auth.decorators.check_api({
-        "permissions": ["models.prompts.prompts.create"],
-        "recommended_roles": {
-            c.ADMINISTRATION_MODE: {"admin": True, "editor": True, "viewer": False},
-            c.DEFAULT_MODE: {"admin": True, "editor": True, "viewer": False},
-        }})
+    @auth.decorators.check_api(
+        {
+            "permissions": ["models.prompts.prompts.create"],
+            "recommended_roles": {
+                c.ADMINISTRATION_MODE: {"admin": True, "editor": True, "viewer": False},
+                c.DEFAULT_MODE: {"admin": True, "editor": True, "viewer": False},
+            },
+        }
+    )
     def post(self, project_id):
         try:
             prompt = prompts_create_prompt(project_id, dict(request.json))
@@ -46,7 +58,6 @@ class ProjectAPI(api_tools.APIModeHandler):
 
 
 class PromptLibAPI(api_tools.APIModeHandler):
-
     def _get_project_id(self, project_id: int | None) -> int:
         if not project_id:
             project_id = 0  # todo: get user personal project id here
@@ -54,10 +65,37 @@ class PromptLibAPI(api_tools.APIModeHandler):
 
     def get(self, project_id: int | None = None, **kwargs):
         project_id = self._get_project_id(project_id)
+        # Pagination parameters
+        limit = request.args.get("limit", default=10, type=int)
+        offset = request.args.get("offset", default=0, type=int)
+
+        # Sorting parameters
+        sort_by = request.args.get("sort_by", default="created_at")
+        sort_order = request.args.get("sort_order", default="desc")
+
+        # Filtering parameters
+        tags = request.args.getlist("tags", type=int)
+        log.info(tags)
 
         with db.with_project_schema_session(project_id) as session:
-            prompts: List[Prompt] = session.query(Prompt).options(
-                joinedload(Prompt.versions).joinedload(PromptVersion.tags)).all()
+            query: List[Prompt] = session.query(Prompt).options(
+                joinedload(Prompt.versions).joinedload(PromptVersion.tags)
+            )
+
+            if tags:
+                query = query.filter(
+                    Prompt.versions.any(PromptVersion.tags.any(PromptTag.id.in_(tags)))
+                )
+
+            # Apply sorting
+            if sort_order.lower() == "asc":
+                query = query.order_by(getattr(Prompt, sort_by))
+            else:
+                query = query.order_by(getattr(Prompt, sort_by).desc())
+
+            # Apply limit and offset for pagination
+            query = query.limit(limit).offset(offset)
+            prompts = query.all()
 
             all_authors = set()
             parsed: List[PromptListModel] = []
@@ -72,31 +110,31 @@ class PromptLibAPI(api_tools.APIModeHandler):
                     all_authors.update(p.author_ids)
                 p.tags = list(tags.values())
                 parsed.append(p)
+
             users = auth.list_users(user_ids=list(all_authors))
-            user_map = {i['id']: i for i in users}
+            user_map = {i["id"]: i for i in users}
 
             for i in parsed:
                 i.set_authors(user_map)
 
-            return [json.loads(i.json(exclude={'author_ids'})) for i in parsed], 200
+            return [json.loads(i.json(exclude={"author_ids"})) for i in parsed], 200
 
     def post(self, project_id: int | None = None, **kwargs):
         project_id = self._get_project_id(project_id)
 
         raw = dict(request.json)
-        raw['owner_id'] = project_id
-        for version in raw.get('versions', []):
-            version['author_id'] = g.auth.id
+        raw["owner_id"] = project_id
+        for version in raw.get("versions", []):
+            version["author_id"] = g.auth.id
         try:
             prompt_data = PromptCreateModel.parse_obj(raw)
         except ValidationError as e:
             return e.errors(), 400
 
         with db.with_project_schema_session(project_id) as session:
-            prompt = Prompt(**prompt_data.dict(
-                exclude_unset=True,
-                exclude={'versions'}
-            ))
+            prompt = Prompt(
+                **prompt_data.dict(exclude_unset=True, exclude={"versions"})
+            )
 
             for ver in prompt_data.versions:
                 create_version(ver, prompt=prompt, session=session)
@@ -104,16 +142,22 @@ class PromptLibAPI(api_tools.APIModeHandler):
             session.commit()
 
             result = PromptDetailModel.from_orm(prompt)
-            result.version_details = PromptVersionDetailModel.from_orm(prompt.versions[0])
-            result.version_details.author = auth.get_user(user_id=result.version_details.author_id)
+            result.version_details = PromptVersionDetailModel.from_orm(
+                prompt.versions[0]
+            )
+            result.version_details.author = auth.get_user(
+                user_id=result.version_details.author_id
+            )
             return json.loads(result.json()), 201
 
 
 class API(api_tools.APIBase):
-    url_params = api_tools.with_modes([
-        '',
-        '<int:project_id>',
-    ])
+    url_params = api_tools.with_modes(
+        [
+            "",
+            "<int:project_id>",
+        ]
+    )
 
     mode_handlers = {
         c.DEFAULT_MODE: ProjectAPI,

--- a/rpc/prompt.py
+++ b/rpc/prompt.py
@@ -14,48 +14,9 @@ from tools import rpc_tools, db
 from ..models.all import (
     Prompt,
     PromptVersion,
-    PromptTag,
 )
 
 class RPC:
-    @web.rpc(f'prompt_lib_list_prompts', "list_prompts")
-    def list_prompts(self, project_id: int, args=None):
-        if args is None:
-            args = {}
-        # Pagination parameters
-        limit = args.get("limit", default=10, type=int)
-        offset = args.get("offset", default=0, type=int)
-
-        # Sorting parameters
-        sort_by = args.get("sort_by", default="created_at")
-        sort_order = args.get("sort_order", default="desc")
-
-        # Filtering parameters
-        tags = args.getlist("tags", type=int)
-
-        with db.with_project_schema_session(project_id) as session:
-            query: List[Prompt] = session.query(Prompt).options(
-                joinedload(Prompt.versions).joinedload(PromptVersion.tags)
-            )
-
-            if tags:
-                query = query.filter(
-                    Prompt.versions.any(PromptVersion.tags.any(PromptTag.id.in_(tags)))
-                )
-
-            # Apply sorting
-            if sort_order.lower() == "asc":
-                query = query.order_by(getattr(Prompt, sort_by))
-            else:
-                query = query.order_by(getattr(Prompt, sort_by).desc())
-            
-            total = query.count()
-            # Apply limit and offset for pagination
-            query = query.limit(limit).offset(offset)
-            prompts = query.all()
-        return total, prompts
-
-
     @web.rpc(f'prompt_lib_get_all', "get_all")
     def prompt_lib_get_all(self, project_id: int, with_versions: bool = False, **kwargs) -> List[dict]:
         # TODO: Support with_versions flag if we still need it

--- a/rpc/prompt.py
+++ b/rpc/prompt.py
@@ -8,14 +8,54 @@ from pydantic import parse_obj_as
 from sqlalchemy.orm import joinedload, load_only, defer
 
 from ..utils.ai_providers import AIProvider
-
-from ..models.all import Prompt, PromptVersion
 from ..models.pd.v1_structure import PromptV1Model, TagV1Model
 from traceback import format_exc
 from tools import rpc_tools, db
-
+from ..models.all import (
+    Prompt,
+    PromptVersion,
+    PromptTag,
+)
 
 class RPC:
+    @web.rpc(f'prompt_lib_list_prompts', "list_prompts")
+    def list_prompts(self, project_id: int, args=None):
+        if args is None:
+            args = {}
+        # Pagination parameters
+        limit = args.get("limit", default=10, type=int)
+        offset = args.get("offset", default=0, type=int)
+
+        # Sorting parameters
+        sort_by = args.get("sort_by", default="created_at")
+        sort_order = args.get("sort_order", default="desc")
+
+        # Filtering parameters
+        tags = args.getlist("tags", type=int)
+
+        with db.with_project_schema_session(project_id) as session:
+            query: List[Prompt] = session.query(Prompt).options(
+                joinedload(Prompt.versions).joinedload(PromptVersion.tags)
+            )
+
+            if tags:
+                query = query.filter(
+                    Prompt.versions.any(PromptVersion.tags.any(PromptTag.id.in_(tags)))
+                )
+
+            # Apply sorting
+            if sort_order.lower() == "asc":
+                query = query.order_by(getattr(Prompt, sort_by))
+            else:
+                query = query.order_by(getattr(Prompt, sort_by).desc())
+            
+            total = query.count()
+            # Apply limit and offset for pagination
+            query = query.limit(limit).offset(offset)
+            prompts = query.all()
+        return total, prompts
+
+
     @web.rpc(f'prompt_lib_get_all', "get_all")
     def prompt_lib_get_all(self, project_id: int, with_versions: bool = False, **kwargs) -> List[dict]:
         # TODO: Support with_versions flag if we still need it


### PR DESCRIPTION
Note: **{{full_path}}/prompt_lib/prompts/prompt_lib/{{project_id}}** API  interface was changed as it returns not only a list of prompts but a dictionary with two fields **rows** and **total**. Total contains all prompts count while rows contain the list of prompts.

To filter by tags, the URL must contain query parameter **tags** and it should contain tags **id** not name. To control pagination **offset** and **limit** url parameters must be supplied. In turn, **sort_by** and **sort_order** url parameters are used for sorting 
